### PR TITLE
Update to new identification format

### DIFF
--- a/client/uploader.js
+++ b/client/uploader.js
@@ -275,6 +275,7 @@ function buildJsonMetadata(sourceHash,snapHash,spriteHash,video240Hash,video480H
                 duration: duration,
                 filesize: filesize,
                 spritehash: spriteHash,
+                provider: 'onelovedtube/0.8.4',
             },
             content: {
                 videohash: sourceHash,


### PR DESCRIPTION
Update to using json_meta.video.info.provider for video uploader identification. Used in dtube network for specifying recommended gateway/embed profile. 

Great work BTW.